### PR TITLE
OSX Port

### DIFF
--- a/glog.go
+++ b/glog.go
@@ -99,7 +99,7 @@ func isatty(f *os.File) bool {
 	}
 	var t syscall.Termios
 	_, _, errno := syscall.Syscall6(syscall.SYS_IOCTL,
-		f.Fd(), syscall.TCGETS,
+		f.Fd(), ioctlTermioFlag,
 		uintptr(unsafe.Pointer(&t)), 0, 0, 0)
 	return errno == 0
 }

--- a/termio_darwin.go
+++ b/termio_darwin.go
@@ -1,0 +1,5 @@
+package glog
+
+import "syscall"
+
+const ioctlTermioFlag = syscall.TIOCGETA

--- a/termio_linux.go
+++ b/termio_linux.go
@@ -1,0 +1,5 @@
+package glog
+
+import "syscall
+
+const ioctlTermioFlag = syscall.TCGETS


### PR DESCRIPTION
Fix terminal I/O flags to compile on Linux or Mac OSX

**NOTE**: This PR is against the `master` branch, not `develop`, because most of the other PRs in this repo have been against `master`. The one exception seems to be #10 which is against `develop` and NOT used by CC 1.0.9 or 1.1.1
