### PR TITLE
Add simple backoff to glog-logstash integration

### DIFF
--- a/glog_logstash.go
+++ b/glog_logstash.go
@@ -17,46 +17,65 @@ type logstashMessage struct {
 // handleLogstashMessages sends logs to logstash.
 func (l *loggingT) handleLogstashMessages() {
 	var conn net.Conn
-	ticker := time.Tick(1 * time.Second)
+
+	initialDelay := 500.0 * time.Millisecond
+	maxDelay := 90.0 * time.Second
+	delay := initialDelay
+	conn, _ = net.DialTimeout("tcp", l.logstashURL, 1*time.Second)
 	for {
 		select {
 		case _ = <-l.logstashStop:
 			conn.Close()
 			return
-		case _ = <-ticker:
-			var err error
-			if conn == nil {
-				fmt.Fprintln(os.Stderr, "Trying to connect to logstash server...", l.logstashURL)
-				conn, err = net.Dial("tcp", l.logstashURL)
-				if err != nil {
-					conn = nil
-				} else {
-					fmt.Fprintln(os.Stderr, "Connected to logstash server.")
-				}
-			}
 		case data := <-l.logstashChan:
 			lm := logstashMessage{}
 			lm.Type = l.logstashType
 			lm.Message = strings.TrimSpace(data)
 			packet, err := json.Marshal(lm)
 			if err != nil {
-				fmt.Fprintln(os.Stderr, "Failed to marshal logstashMessage.")
+				fmt.Fprintf(os.Stderr, "%s: Failed to marshall logstashMessage.\n",  msgPrefix())
 				continue
-			}
-			if conn != nil {
+			} else if conn != nil {
 				_, err := fmt.Fprintln(conn, string(packet))
 				if err != nil {
-					fmt.Fprintln(os.Stderr, "Not connected to logstash server, attempting reconnect.")
 					conn = nil
-					continue
+					//fmt.Fprintf(os.Stderr, "%s: Failed to write to logstash server; err=%s\n", msgPrefix(), err)
+				} else {
+					// reset the delay once we were able to write something to logstash
+					delay = initialDelay
+					// fmt.Fprintf(os.Stderr, "%s: write logstashMessage complete.\n",  msgPrefix())
 				}
 			} else {
 				// There is no connection, so the log line is dropped.
 				// Might be nice to add a buffer here so that we can ship
 				// logs after the connection is up.
 			}
+		default:
+			time.Sleep(1 * time.Second)
+		}
+
+		if conn == nil {
+			delay *= 2.0
+			if delay > maxDelay {
+				delay = maxDelay
+			}
+			// fmt.Fprintf(os.Stderr, "%s: no connection; sleeping %2.2f\n",  msgPrefix(), delay.Seconds())
+			time.Sleep(delay)
+
+			// fmt.Fprintf(os.Stderr, "%s: Trying to connect to logstash server %s\n", msgPrefix(), l.logstashURL)
+			var err error
+			conn, err = net.DialTimeout("tcp", l.logstashURL, 1*time.Second)
+			if err != nil {
+				conn = nil
+				//fmt.Fprintf(os.Stderr, "%s: Failed to connect to logstash server; err=%s\n", msgPrefix(), err)
+			}
 		}
 	}
+}
+
+// Message prefix for direct writes to stderr
+func msgPrefix() string {
+	return fmt.Sprintf("glog: %s: ", time.Now().Format("15:04:05.00000"))
 }
 
 // StartLogstash creates the logstash channel and kicks off handleLogstashMessages.

--- a/glog_logstash.go
+++ b/glog_logstash.go
@@ -39,11 +39,9 @@ func (l *loggingT) handleLogstashMessages() {
 				_, err := fmt.Fprintln(conn, string(packet))
 				if err != nil {
 					conn = nil
-					//fmt.Fprintf(os.Stderr, "%s: Failed to write to logstash server; err=%s\n", msgPrefix(), err)
 				} else {
 					// reset the delay once we were able to write something to logstash
 					delay = initialDelay
-					// fmt.Fprintf(os.Stderr, "%s: write logstashMessage complete.\n",  msgPrefix())
 				}
 			} else {
 				// There is no connection, so the log line is dropped.
@@ -59,15 +57,12 @@ func (l *loggingT) handleLogstashMessages() {
 			if delay > maxDelay {
 				delay = maxDelay
 			}
-			// fmt.Fprintf(os.Stderr, "%s: no connection; sleeping %2.2f\n",  msgPrefix(), delay.Seconds())
 			time.Sleep(delay)
 
-			// fmt.Fprintf(os.Stderr, "%s: Trying to connect to logstash server %s\n", msgPrefix(), l.logstashURL)
 			var err error
 			conn, err = net.DialTimeout("tcp", l.logstashURL, 1*time.Second)
 			if err != nil {
 				conn = nil
-				//fmt.Fprintf(os.Stderr, "%s: Failed to connect to logstash server; err=%s\n", msgPrefix(), err)
 			}
 		}
 	}


### PR DESCRIPTION
This is a simple approach to keep this integration from spamming connect attempts when logstash is not reachable. Will likely be removed altogether in the near future